### PR TITLE
Calib

### DIFF
--- a/calibration_coil.m
+++ b/calibration_coil.m
@@ -11,472 +11,418 @@ addAnalogOutputChannel(session,'Dev2','ao0', 'Voltage');
 % Read teslameter or displacement sensor output.
 addAnalogInputChannel(session,'Dev2','ai1', 'Voltage');
 
-%% Define coil impulses as stimuli.
-
 sr = session_sampling_rate/1000;  % Sampling rate in ms.
 baseline_dur = 2000;
 trial_dur = 4000;
 
-% Blank stimulus.
-blank = zeros(1,trial_dur*sr);
+%% Choose stimulus and define impulse
+
+% stim_name = 'biphasic_square_35';
+stim_name = 'biphasic_square_3ms_35';
+% stim_name = 'biphasic_hann_3ms_40';
+% stim_name = 'biphasic_hann_35';
+% stim_name = 'biphasic_hann_3ms_30';
+% stim_name = 'monophasic_hann_1ms_35';
+% stim_name = 'monophasic_hann_3ms_35';
+% stim_name = 'blank';
+
+
+if strcmp(stim_name,'blank')
+
+    % Blank stimulus.
+    blank = zeros(1,trial_dur*sr);
+   
+elseif strcmp(stim_name,'biphasic_square_35')
+
+    % Biphasic square pulse 1 ms 35 mT.
+    
+    stim_amp = 3.3;
+    stim_duration = 1;
+    scale_factor = .95;
+    
+    stim_duration_up = stim_duration/2*sr+6;
+    stim_duration_down = stim_duration/2*sr+1;
+    
+    biphasic_square_35 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
+    stim = [biphasic_square_35 zeros(1,trial_dur*sr-numel(biphasic_square_35))];
+
+elseif strcmp(stim_name,'biphasic_square_3ms_35')
+
+    % Biphasic square pulse 3 ms 35 mT.
+    
+    stim_amp = 3.3;
+    stim_duration = 3;
+    scale_factor = .95;
+    
+    stim_duration_up = stim_duration/2*sr+6;
+    stim_duration_down = stim_duration/2*sr+1;
+    
+    biphasic_square_3ms_35 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
+    stim = [biphasic_square_3ms_35 zeros(1,trial_dur*sr-numel(biphasic_square_3ms_35))];
+
+
+elseif strcmp(stim_name,'biphasic_square_30')
+    
+    % Biphasic square pulse 1 ms 30 mT.
+
+    stim_amp = 2.8;
+    stim_duration = 1;
+    scale_factor = .95;
+    
+    stim_duration_up = stim_duration/2*sr+6;
+    stim_duration_down = stim_duration/2*sr+1;
+    
+    biphasic_square_30 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
+    stim = [biphasic_square_30 zeros(1,trial_dur*sr-numel(biphasic_square_30))];
+
+elseif strcmp(stim_name,'biphasic_hann_35')
+    % Biphasic Hann window 1.6 ms 35 mT.
+
+    stim_amp = 4;
+    stim_duration_up = 1;
+    stim_duration_down = .6;
+    scale_factor = 1.85;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_35 zeros(1,trial_dur*sr - numel(biphasic_hann_35))];
+
+
+elseif strcmp(stim_name,'biphasic_hann_30')
+
+    % Biphasic Hann window 1.6 ms 30 mT.
+    
+    stim_amp = 3.2;
+    stim_duration_up = 1;
+    stim_duration_down = .6;
+    scale_factor = 1.6;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_30 zeros(1,trial_dur*sr - numel(biphasic_hann_30))];
+
+elseif strcmp(stim_name,'biphasic_hann_25')
+    % Biphasic Hann window 1.6 ms 25 mT.
+    
+    stim_amp = 2.4;
+    stim_duration_up = 1;
+    stim_duration_down = .6;
+    scale_factor = 1.3;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_25 zeros(1,trial_dur*sr - numel(biphasic_hann_25))];
+
+elseif strcmp(stim_name,'biphasic_hann_20')
+    % Biphasic Hann window 1.6 ms 20 mT.
+    
+    stim_amp = 2.2;
+    stim_duration_up = 1;
+    stim_duration_down = .6;
+    scale_factor = 1.3;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_20 zeros(1,trial_dur*sr - numel(biphasic_hann_20))];
+
+elseif strcmp(stim_name, 'biphasic_hann_15')
+    % Biphasic Hann window 1.6 ms 15 mT.
+    
+    stim_amp = 1.7;
+    stim_duration_up = 1;
+    stim_duration_down = .6;
+    scale_factor = 1.25;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_15 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_15 zeros(1,trial_dur*sr - numel(biphasic_hann_15))];
+
+elseif strcmp(stim_name,'biphasic_hann_3ms_40')
+
+    % Biphasic Hann window 3 ms 40 mT.
+    
+    stim_amp = 3.2;
+    stim_duration_up = 1.5;
+    stim_duration_down = 1.5;
+    scale_factor = .9;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr-5;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_3ms_40 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_3ms_40 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_40))];
+
+elseif strcmp(stim_name,'biphasic_hann_3ms_35')
+
+    % Biphasic Hann window 3 ms 35 mT.
+    
+    stim_amp = 2.85;
+    stim_duration_up = 1.5;
+    stim_duration_down = 1.5;
+    scale_factor = .6;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr-5;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_3ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_3ms_35 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_35))];
+
+elseif strcmp(stim_name, 'biphasic_hann_3ms_30')
+
+    % Biphasic Hann window 3 ms 30 mT.
+    
+    stim_amp = 2.3;
+    stim_duration_up = 1.5;
+    stim_duration_down = 1.5;
+    scale_factor = .6;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_3ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_3ms_30 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_30))];
+
+elseif strcmp(stim_name, 'biphasic_hann_3ms_25')
+    % Biphasic Hann window 3 ms 25 mT.
+    
+    stim_amp = 1.95;
+    stim_duration_up = 1.5;
+    stim_duration_down = 1.5;
+    scale_factor = .6;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    biphasic_hann_3ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [biphasic_hann_3ms_25 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_25))];
+
+elseif strcmp(stim_name,'monophasic_hann_1ms_35')
+
+    % Monophasic Hann window 1 ms 35 mT.
+    
+    stim_amp = 4;
+    stim_duration_up = 1;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_1ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_1ms_35 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_35))];
+
+
+elseif strcmp(stim_name, 'monophasic_hann_1ms_30')
+    % Monophasic Hann window 1 ms 30 mT.
+    
+    stim_amp = 3.2;
+    stim_duration_up = 1;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_1ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_1ms_30 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_30))];
+
+elseif strcmp(stim_name,'monophasic_hann_1ms_25')
+    % Monophasic Hann window 1 ms 25 mT.
+    
+    stim_amp = 2.6;
+    stim_duration_up = 1;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_1ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_1ms_25 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_25))];
+
+elseif strcmp(stim_name,'monophasic_hann_1ms_20')
+    % Monophasic Hann window 1 ms 20 mT.
+    
+    stim_amp = 2;
+    stim_duration_up = 1;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_1ms_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_1ms_20 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_20))];
+
+elseif strcmp(stim_name,'monophasic_hann_3ms_35')
+    
+    
+    % Monophasic Hann window 3 ms 35 mT.
+    
+    stim_amp = 1.6;
+    stim_duration_up = 3;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_3ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_3ms_35 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_35))];
+
+elseif strcmp(stim_name,'monophasic_hann_3ms_30')
+
+    % Monophasic Hann window 3 ms 30 mT.
+    
+    stim_amp = 1.4;
+    stim_duration_up = 3;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_3ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_3ms_30 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_30))];
+
+elseif strcmp(stim_name, 'monophasic_hann_3ms_25')
+    % Monophasic Hann window 3 ms 25 mT.
+    
+    stim_amp = 1.1;
+    stim_duration_up = 3;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_3ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_3ms_25 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_25))];
+
+elseif strcmp(stim_name, 'monophasic_hann_3ms_20')
+
+    % Monophasic Hann window 3 ms 20 mT.
+    
+    stim_amp = .85;
+    stim_duration_up = 3;
+    stim_duration_down = 0;
+    
+    stim_duration_up = stim_duration_up*sr;
+    stim_duration_down = stim_duration_down*sr;
+    
+    impulse_up = tukeywin(stim_duration_up,1);
+    impulse_up = impulse_up(1:end-1);
+    impulse_down = -tukeywin(stim_duration_down,1);
+    impulse_down = impulse_down(2:end);
+    impulse = [impulse_up' scale_factor*impulse_down'];
+    
+    monophasic_hann_3ms_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
+    stim = [monophasic_hann_3ms_20 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_20))];
+
+end
 
-% Biphasic square pulse 1 ms 35 mT.
-
-stim_amp = 3.3;
-stim_duration = 1;
-scale_factor = .95;
-
-stim_duration_up = stim_duration/2*sr+6;
-stim_duration_down = stim_duration/2*sr+1;
-
-biphasic_square_35 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
-biphasic_square_35 = [biphasic_square_35 zeros(1,trial_dur*sr-numel(biphasic_square_35))];
-
-% Biphasic square pulse 3 ms 35 mT.
-
-stim_amp = 3.3;
-stim_duration = 3;
-scale_factor = .95;
-
-stim_duration_up = stim_duration/2*sr+6;
-stim_duration_down = stim_duration/2*sr+1;
-
-biphasic_square_3ms_35 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
-biphasic_square_3ms_35 = [biphasic_square_3ms_35 zeros(1,trial_dur*sr-numel(biphasic_square_3ms_35))];
-
-
-% Biphasic square pulse 1 ms 30 mT.
-
-stim_amp = 2.8;
-stim_duration = 1;
-scale_factor = .95;
-
-stim_duration_up = stim_duration/2*sr+6;
-stim_duration_down = stim_duration/2*sr+1;
-
-biphasic_square_30 = stim_amp*[zeros(1,baseline_dur*sr) ones(1,stim_duration_up) -ones(1,stim_duration_down)*scale_factor];
-biphasic_square_30 = [biphasic_square_30 zeros(1,trial_dur*sr-numel(biphasic_square_30))];
-
-% Biphasic Hann window 1.6 ms 35 mT.
-
-stim_amp = 4;
-stim_duration_up = 1;
-stim_duration_down = .6;
-scale_factor = 1.85;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_35 = [biphasic_hann_35 zeros(1,trial_dur*sr - numel(biphasic_hann_35))];
-
-
-% Biphasic Hann window 1.6 ms 30 mT.
-
-stim_amp = 3.2;
-stim_duration_up = 1;
-stim_duration_down = .6;
-scale_factor = 1.6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_30 = [biphasic_hann_30 zeros(1,trial_dur*sr - numel(biphasic_hann_30))];
-
-% Biphasic Hann window 1.6 ms 25 mT.
-
-stim_amp = 2.4;
-stim_duration_up = 1;
-stim_duration_down = .6;
-scale_factor = 1.3;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_25 = [biphasic_hann_25 zeros(1,trial_dur*sr - numel(biphasic_hann_25))];
-
-
-% Biphasic Hann window 1.6 ms 20 mT.
-
-stim_amp = 2.2;
-stim_duration_up = 1;
-stim_duration_down = .6;
-scale_factor = 1.3;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_20 = [biphasic_hann_20 zeros(1,trial_dur*sr - numel(biphasic_hann_20))];
-
-% Biphasic Hann window 1.6 ms 15 mT.
-
-stim_amp = 1.7;
-stim_duration_up = 1;
-stim_duration_down = .6;
-scale_factor = 1.25;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_15 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_15 = [biphasic_hann_15 zeros(1,trial_dur*sr - numel(biphasic_hann_15))];
-
-
-% Biphasic Hann window 3 ms 40 mT.
-
-stim_amp = 3.2;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .9;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr-5;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_40 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_40 = [biphasic_hann_3ms_40 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_40))];
-
-% Biphasic Hann window 3 ms 35 mT.
-
-stim_amp = 2.85;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr-5;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_35 = [biphasic_hann_3ms_35 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_35))];
-
-% Biphasic Hann window 3 ms 30 mT.
-
-stim_amp = 2.3;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_30 = [biphasic_hann_3ms_30 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_30))];
-
-
-% Biphasic Hann window 3 ms 25 mT.
-
-stim_amp = 1.95;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_25 = [biphasic_hann_3ms_25 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_25))];
-
-
-
-% Biphasic Hann window 3 ms 20 mT.
-
-stim_amp = 1.5;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_20 = [biphasic_hann_3ms_20 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_20))];
-
-
-% Biphasic Hann window 3 ms 15 mT.
-
-stim_amp = 1.2;
-stim_duration_up = 1.5;
-stim_duration_down = 1.5;
-scale_factor = .6;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-biphasic_hann_3ms_15 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-biphasic_hann_3ms_15 = [biphasic_hann_3ms_15 zeros(1,trial_dur*sr - numel(biphasic_hann_3ms_15))];
-
-
-%%%%
-
-% Monophasic Hann window 1 ms 35 mT.
-
-stim_amp = 4;
-stim_duration_up = 1;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_1ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_1ms_35 = [monophasic_hann_1ms_35 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_35))];
-
-
-% Monophasic Hann window 1 ms 30 mT.
-
-stim_amp = 3.2;
-stim_duration_up = 1;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_1ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_1ms_30 = [monophasic_hann_1ms_30 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_30))];
-
-% Monophasic Hann window 1 ms 25 mT.
-
-stim_amp = 2.6;
-stim_duration_up = 1;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_1ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_1ms_25 = [monophasic_hann_1ms_25 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_25))];
-
-
-% Monophasic Hann window 1 ms 20 mT.
-
-stim_amp = 2;
-stim_duration_up = 1;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_1ms_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_1ms_20 = [monophasic_hann_1ms_20 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_20))];
-
-
-% Monophasic Hann window 1 ms 15 mT.
-
-stim_amp = 1.45;
-stim_duration_up = 1;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_1ms_15 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_1ms_15 = [monophasic_hann_1ms_15 zeros(1,trial_dur*sr - numel(monophasic_hann_1ms_15))];
-
-
-%%%%
-
-% Monophasic Hann window 3 ms 35 mT.
-
-stim_amp = 1.6;
-stim_duration_up = 3;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_3ms_35 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_3ms_35 = [monophasic_hann_3ms_35 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_35))];
-
-
-% Monophasic Hann window 3 ms 30 mT.
-
-stim_amp = 1.4;
-stim_duration_up = 3;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_3ms_30 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_3ms_30 = [monophasic_hann_3ms_30 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_30))];
-
-% Monophasic Hann window 3 ms 25 mT.
-
-stim_amp = 1.1;
-stim_duration_up = 3;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_3ms_25 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_3ms_25 = [monophasic_hann_3ms_25 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_25))];
-
-
-% Monophasic Hann window 3 ms 20 mT.
-
-stim_amp = .85;
-stim_duration_up = 3;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_3ms_20 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_3ms_20 = [monophasic_hann_3ms_20 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_20))];
-
-
-% Monophasic Hann window 3 ms 15 mT.
-
-stim_amp = 0.6;
-stim_duration_up = 3;
-stim_duration_down = 0;
-
-stim_duration_up = stim_duration_up*sr;
-stim_duration_down = stim_duration_down*sr;
-
-impulse_up = tukeywin(stim_duration_up,1);
-impulse_up = impulse_up(1:end-1);
-impulse_down = -tukeywin(stim_duration_down,1);
-impulse_down = impulse_down(2:end);
-impulse = [impulse_up' scale_factor*impulse_down'];
-
-monophasic_hann_3ms_15 = stim_amp * [zeros(1,baseline_dur*sr) impulse];
-monophasic_hann_3ms_15 = [monophasic_hann_3ms_15 zeros(1,trial_dur*sr - numel(monophasic_hann_3ms_15))];
 
 
 %% Test stimulus and plot.
-
-% Choose stim and run
-% stim = biphasic_square_35;
-% stim = biphasic_square_3ms_35;
-stim = biphasic_hann_3ms_40;
-% stim = biphasic_hann_35;
-% stim = biphasic_hann_3ms_30;
-% stim = monophasic_hann_1ms_35;
-% stim = monophasic_hann_3ms_35;
-% stim = blank;
 
 
 ntrials = 5;
@@ -514,11 +460,11 @@ linkaxes([ax1,ax2],'x')
 path_write = 'K:\BehaviourCode\Calibration';
 
 date = datetime('today', 'Format', 'yyyymmdd');
-file = [int2str(yyyymmdd(date)) '_calibration_stim_magnetic_flux_biphasic_hann_3ms_40.m'];
+file = [int2str(yyyymmdd(date)) '_calibration_stim_magnetic_flux_' stim_name '.m'];
 
 file = fullfile(path_write, file);
 save(file,'ntrials','flux_data','stim','stim_amp','stim_duration_up','stim_duration_down','scale_factor', 'session_sampling_rate')
-disp('Calibration data saved.')
+disp(['Calibration data saved in: ' file])
 
 
 

--- a/stop_sessions.m
+++ b/stop_sessions.m
@@ -89,7 +89,5 @@ writetable(results_table, [folder_name '\results.csv']);
 % Save session config post session
 set(handles2give.OnlineTextTag,'String', 'Session Stopped', 'FontWeight', 'Bold');
 
-clear all
-clc
 disp('Session Stopped.')
 


### PR DESCRIPTION
Minor changes for saving calibraition data. I thought better if we want to be more consistent and e.g. show tuning curves of stimulus shapes <-> magnetic flux more easily like @aprrenard did when we designed new stimuli.
File name auto generated from choice of stimulus.
Saves all calibration data: flux measurements, stim parameters, duration.
