### PR TITLE
Perf fcn

### DIFF
--- a/compute_performance.m
+++ b/compute_performance.m
@@ -1,0 +1,25 @@
+function [aud_hit_rate,wh_hit_rate,fa_rate,stim_trial_number,aud_stim_number,wh_stim_number] = compute_performance(results)
+%COMPUTE_PERFORMANCE Compute session-wide performance.
+% RESULTS: results structure to compute metrics from.
+
+non_asso_trials = results.data(:,4)~=1;
+
+% Get perf column and trial types
+perf = results.data(non_asso_trials, 2);
+aud_trials = results.data(non_asso_trials, 13);
+wh_trials = results.data(non_asso_trials, 12);
+stim_trials = results.data(non_asso_trials, 11);
+
+% Compute performance and completed trial counts 
+stim_trial_number = sum(stim_trials==1);
+
+aud_stim_number = sum(aud_trials==1); 
+aud_hit_rate = round(sum(perf==3)/aud_stim_number*100)/100;
+
+wh_stim_number = sum(wh_trials==1);
+wh_hit_rate = round(sum(perf==2)/wh_stim_number*100)/100;
+
+fa_rate = round(sum(perf==5)/sum(stim_trials==0)*100)/100;
+
+end
+

--- a/compute_reward_volume.m
+++ b/compute_reward_volume.m
@@ -1,0 +1,25 @@
+function [aud_tot_volume, wh_tot_volume, asso_tot_volume] = compute_reward_volume(results, volume_per_reward)
+%COMPUTE_REWARD_VOLUME Compute collected reward volumne per trial types,
+% regardless of the flag wh_reward of context block (theoretical reward volume if all rewarded).
+%   RESULTS:  results structure to compute metrics from.
+%   VOLUME_PER_REWARD: volume per reward, in microliter.
+
+% Separate associative form non-associative trials
+asso_trials = results.data(:,4)==1;
+asso_stim_trials = results.data(asso_trials, 11);
+non_asso_trials = results.data(:,4)~=1;
+
+% Get rewards obtained per trial type
+reward_trials_non_asso = results.data(non_asso_trials,14)==1; %=1 only if reward_proba=1
+perf = results.data(non_asso_trials, 2);
+aud_hits = perf==3;
+wh_hits = perf==2;
+aud_trials_rewarded = results.data(aud_hits & reward_trials_non_asso, 13); %element-wise vector comparison
+wh_trials_rewarded = results.data(wh_hits & reward_trials_non_asso, 12);
+
+% Get volumes: auditory, whisker, associative trials
+aud_tot_volume = volume_per_reward * sum(aud_trials_rewarded);
+wh_tot_volume = volume_per_reward * sum(wh_trials_rewarded);
+asso_tot_volume = volume_per_reward * sum(asso_stim_trials);
+
+end

--- a/main_control.m
+++ b/main_control.m
@@ -73,7 +73,7 @@ function main_control(~,event)
     end
 
 
-    %% Detecting rewarded licks and trigger reward.
+    %% Detecting rewarded licks and trigger reward. 
     % --------------------------------------------
 
     if trial_started_flag && ~association_flag  && ... %check if currently within a trial
@@ -88,7 +88,7 @@ function main_control(~,event)
         if aud_reward && ~wh_reward
             if is_auditory
                 hit_time=toc(trial_start_time);
-                reward_delivery(is_stim, is_auditory, is_whisker, aud_reward, wh_reward); %deliver reward
+                reward_delivery; %deliver reward
                 first_threshold_cross=find(abs(event.Data(1:end-1,1))<lick_threshold & abs(event.Data(2:end,1))>lick_threshold',1,'first');
                 hit_time_adjusted=hit_time-first_threshold_cross/Main_S_SR;
                 reaction_time=hit_time_adjusted-(baseline_window)/1000;
@@ -114,13 +114,30 @@ function main_control(~,event)
 
         elseif aud_reward && wh_reward
             hit_time=toc(trial_start_time);
-            reward_delivery(is_stim, is_auditory, is_whisker, aud_reward, wh_reward);
+            reward_delivery;
             first_threshold_cross=find(abs(event.Data(1:end-1,1))<lick_threshold & abs(event.Data(2:end,1))>lick_threshold',1,'first');
             hit_time_adjusted=hit_time-first_threshold_cross/Main_S_SR;
             reaction_time=hit_time_adjusted-(baseline_window)/1000;
-
             mouse_licked_flag=1;
             perf_and_save_results_flag=1;
+
+        elseif ~aud_reward && wh_reward
+            if is_auditory
+                hit_time=toc(trial_start_time);
+                first_threshold_cross=find(abs(event.Data(1:end-1,1))<lick_threshold & abs(event.Data(2:end,1))>lick_threshold',1,'first');
+                hit_time_adjusted=hit_time-first_threshold_cross/Main_S_SR;
+                reaction_time=hit_time_adjusted-(baseline_window)/1000;
+                mouse_licked_flag=1;
+                perf_and_save_results_flag=1;
+            elseif is_whisker
+                hit_time=toc(trial_start_time);
+                reward_delivery;
+                first_threshold_cross=find(abs(event.Data(1:end-1,1))<lick_threshold & abs(event.Data(2:end,1))>lick_threshold',1,'first');
+                hit_time_adjusted=hit_time-first_threshold_cross/Main_S_SR;
+                reaction_time=hit_time_adjusted-(baseline_window)/1000;
+                mouse_licked_flag=1;
+                perf_and_save_results_flag=1;
+            end
         end
     end
 

--- a/reward_delivery.m
+++ b/reward_delivery.m
@@ -1,20 +1,12 @@
-function reward_delivery(is_stim, is_auditory, is_whisker, aud_reward, wh_reward)
+function reward_delivery
 % REWARD_DELIVERY Gives unitary reward if conditions are met.
 
     global Trigger_S reward_time reward_delivered_flag ...
 
-    % Reward only stimulus trials
-    %if  is_stim
+    %Trigger reward signal (pulse defined in update_parameters.m)
+    outputSingleScan(Trigger_S, [0 1 0]);
 
-        %% Check if stimulus trials are rewarded
-    %    if (is_auditory && aud_reward) || (is_whisker && wh_reward) 
-
-        %Trigger reward signal (pulse defined in update_parameters.m)
-        outputSingleScan(Trigger_S, [0 1 0]);
-
-        reward_time=tic;
-        reward_delivered_flag=1;
+    reward_time=tic;
+    reward_delivered_flag=1;
             
-%         end
-%     end
 end

--- a/update_parameters.m
+++ b/update_parameters.m
@@ -8,7 +8,7 @@ function update_parameters
         false_alarm_punish_flag false_alarm_timeout early_lick_punish_flag early_lick_timeout ...
         Stim_S Log_S wh_stim_duration  aud_stim_duration  aud_stim_amp  aud_stim_freq  Stim_S_SR ScansTobeAcquired ...
         Reward_S Reward_S_SR  Trigger_S fid_lick_trace mouse_licked_flag reaction_time ...
-        trial_started_flag  trial_number light_proba_old folder_name handles2give...
+        trial_started_flag  trial_number main_pool_size_old light_proba_old folder_name handles2give...
         stim_proba_old aud_stim_proba_old wh_stim_proba_old aud_light_proba_old wh_light_proba_old light_flag baseline_window camera_vec...
         deliver_reward_flag ...
         wh_stim_amp wh_scaling_factor response_window_start response_window_end...
@@ -143,7 +143,7 @@ function update_parameters
     wh_scaling_factor = handles2give.wh_scaling_factor;
 
     aud_stim_weight = handles2give.aud_stim_weight;
-    wh_stim_weight = handles2give.wh_stim_weight; %for whisker , hard-coded for now (see below)
+    wh_stim_weight = handles2give.wh_stim_weight; 
     no_stim_weight = handles2give.no_stim_weight;
     
 
@@ -197,6 +197,11 @@ function update_parameters
     % Size of pool (i.e. trial block) to get trials from
     % If context is not used:
     main_pool_size = aud_stim_weight + wh_stim_weight + no_stim_weight; %in an non-light task
+    if isempty(main_pool_size_old)
+        main_pool_size_old = main_pool_size;
+    end
+
+    
     % If use context blocks (check sum is valid) 
     if context_flag
         if context_block_size ~= main_pool_size
@@ -217,9 +222,11 @@ function update_parameters
     wh_stim_proba_old = wh_stim_proba;
 
     % CREATE NEW TRIAL POOL WHEN CURRENT POOL FINISHED
+    disp(main_pool_size_old);
+    disp(main_pool_size);
 
-    if mod(n_completed_trials, main_pool_size)==0 || light_proba_old ~= light_proba || aud_light_proba_old ~= light_aud_proba ||  wh_light_proba_old ~= light_wh_proba ||stim_proba_old ~= stim_proba || aud_stim_proba_old ~= aud_stim_proba|| wh_stim_proba_old ~= wh_stim_proba
-
+    if mod(n_completed_trials, main_pool_size)==0 || main_pool_size_old ~= main_pool_size|| stim_proba_old ~= stim_proba || aud_stim_proba_old ~= aud_stim_proba|| wh_stim_proba_old ~= wh_stim_proba || light_proba_old ~= light_proba || aud_light_proba_old ~= light_aud_proba ||  wh_light_proba_old ~= light_wh_proba
+        main_pool_size_old = main_pool_size;
         % Stim. probability and trial pool when light stimulus
         if light_flag
 
@@ -250,7 +257,7 @@ function update_parameters
         %Randomize occurrence of trials in pool
         main_trial_pool=main_trial_pool(randperm(numel(main_trial_pool)));
 
-        % specify absence of context
+        % Specify absence of context
         context_code = 0;
 
         % if context 

--- a/update_parameters.m
+++ b/update_parameters.m
@@ -571,18 +571,19 @@ function update_parameters
         if is_auditory
 
             set(handles2give.TrialTimeLineTextTag,'String', ['Next trial: Auditory.  ' char(trial_titles(is_stim+2)) ' '...
-                char(association_titles(association_flag+1)) '   ' char(reward_titles(is_reward+1)) '     ' char(light_titles(is_light+1))],'ForegroundColor',acolor);
+                char(association_titles(association_flag+1)) '   ' char(reward_titles(aud_reward+1)) '     ' char(light_titles(is_light+1))],'ForegroundColor',acolor);
 
         else
-            %if is_reward %&& wh_reward
-            %    reward_title = 'Rewarded';
-            %else%if ~wh_reward || ~is_reward
-            %    reward_title = 'Not rewarded';
-            %end
-            reward_title=reward_titles(wh_reward+1);
+            if is_reward==1 % =1 always when no partial rewards
+                reward_title = 'Rewarded';
+                wcolor = [0.4660 0.6740 0.1880]';
+            else
+                reward_title = 'Not rewarded';
+                wcolor = [0.6350 0.0780 0.1840];
+            end
             
             set(handles2give.TrialTimeLineTextTag,'String',['Next trial: Whisker. ' char(trial_titles(is_stim+1)) ' '...
-                char(association_titles(association_flag+1)) '   ' char(reward_title) '     ' char(light_titles(is_light+1))],'ForegroundColor',wcolor);
+                char(association_titles(association_flag+1)) '   ' char(reward_title) '     ' char(light_titles(is_light+1))],'ForegroundColor', wcolor);
 
         end
 


### PR DESCRIPTION
This fixes:
#14 auditory reward OFF works as intended (although not needed)
#24 fixed text in GUI when no reward for whisker
#25 two functions to compute session performance and reward volume collected using as input `results` + specific arguments (e.g. volume_per_reward) Note: this is generic and does not take into account block design... to be done at some point (depending on how context experimentalists want to display such info, if they do...)

