### PR TITLE
Add Context transition to the continuous log

### DIFF
--- a/calibration_coil.m
+++ b/calibration_coil.m
@@ -9,7 +9,7 @@ addAnalogOutputChannel(session,'Dev2','ao0', 'Voltage');
 % channel_coil = addAnalogOutputChannel(session,'PXI1Slot2','ao0', 'Voltage');
 
 % Read teslameter or displacement sensor output.
-addAnalogInputChannel(session,'Dev2','ai5', 'Voltage');
+addAnalogInputChannel(session,'Dev2','ai6', 'Voltage');
 
 sr = session_sampling_rate/1000;  % Sampling rate in ms.
 baseline_dur = 2000;

--- a/defining_sessions.m
+++ b/defining_sessions.m
@@ -9,7 +9,7 @@
         lh1 lh2 fid_results  Reward_S_SR local_counter lick_channel_times camera_start_time ...
         folder_name handles2give early_lick_counter session_start_time...
         Main_S_SR Reward_Ch light_counter whisker_trial_counter...
-        fid_continuous trial_start_ttl lick_data cam1_ttl cam2_ttl scan_pos continuous_lick_data Camera_S
+        fid_continuous trial_start_ttl lick_data cam1_ttl cam2_ttl scan_pos continuous_lick_data Camera_S Context_S context_ttl
 
 
     % Initialize variables and result file
@@ -33,6 +33,7 @@
     cam1_ttl = zeros(1,10*Log_S_SR);
     cam2_ttl = zeros(1,10*Log_S_SR);
     scan_pos = zeros(1,10*Log_S_SR);
+    context_ttl =  zeros(1,10*Log_S_SR);
     
     % Create and open session result file
     folder_name=[char(handles2give.behaviour_directory) '\' char(handles2give.mouse_name) ...
@@ -79,13 +80,15 @@
     % ai2: trial start ttl
     % ai3: camera 1
     % ai4: camera 2
+    % ai5: context transition
     
-    ai_log = addAnalogInputChannel(Log_S, 'Dev2', [0,1,2,3,4], 'Voltage');
+    ai_log = addAnalogInputChannel(Log_S, 'Dev2', [0,1,2,3,4, 5], 'Voltage');
     ai_log(1).TerminalConfig='SingleEnded';
     ai_log(2).TerminalConfig='SingleEnded';
     ai_log(3).TerminalConfig='SingleEnded';
     ai_log(4).TerminalConfig='SingleEnded';
     ai_log(5).TerminalConfig='SingleEnded';
+    ai_log(6).TerminalConfig='SingleEnded';
     Log_S.Rate = Log_S_SR;
     Log_S.IsContinuous = true;
     lh2 = addlistener(Log_S,'DataAvailable', @(src, event) log_continuously(src, event));
@@ -144,7 +147,10 @@
     cam_ch.Frequency = handles2give.camera_freq; %Hz
     cam_ch.DutyCycle = (handles2give.camera_exposure_time / 1000 ) / (1 / cam_ch.Frequency);
     cam_ch.InitialDelay = handles2give.camera_start_delay;
-   
+    
+    % Session for context block switch output
+    Context_S = daq.createSession('ni');
+    addDigitalChannel(Context_S,'Dev2', 'Port0/Line2', 'OutputOnly'); %  Context channel
 
     % Run Main Control
     % ----------------
@@ -156,7 +162,7 @@
     early_lick_counter = 0;
     local_counter = 0; % for plot_lick_trace
     whisker_trial_counter = 0; %for partial rewards
-
+ 
     % Update parameters in GUI
     update_parameters;
 

--- a/main_control.m
+++ b/main_control.m
@@ -28,25 +28,7 @@ function main_control(~,event)
         lick_time=tic;
     end
 
-    %% Play context noise backgrounds
-    if context_flag
-        if strcmp(context_block, 'pink')
-            if ~ pink_noise_player.isplaying
-                pink_noise_player.play
-            end
-            if brown_noise_player.isplaying
-                brown_noise_player.pause
-            end
-        elseif strcmp(context_block, 'brown')
-            if ~ brown_noise_player.isplaying
-                brown_noise_player.play
-            end
-            if pink_noise_player.isplaying
-                pink_noise_player.pause
-            end
-        end
-    end
-
+    
     %% Stimulus delivery at trial start.
     % ------------------
 

--- a/update_parameters.m
+++ b/update_parameters.m
@@ -16,7 +16,7 @@ function update_parameters
         is_reward reward_pool partial_reward_flag reward_proba_old...
         light_duration light_freq light_amp camera_freq SITrigger_vec main_trial_pool...
         whisker_trial_counter mouse_rewarded_context context_block context_flag block_id wh_rewarded_context...
-        pink_noise_player brown_noise_player identical_block_count extra_time 
+        pink_noise_player brown_noise_player identical_block_count extra_time Context_S
         
        
 
@@ -226,6 +226,8 @@ function update_parameters
                 mouse_rewarded_context = get_or_determine_mouse_rewarded_context(handles2give.context_table_directory, handles2give.mouse_name, contexts);
                 block_id = randi([1, size(contexts, 2)], 1); 
                 context_block = contexts(block_id);
+                outputSingleScan(Context_S,[0])
+                play_context_background(context_block, pink_noise_player, brown_noise_player, Context_S)
             else
                 old_block_id = block_id;
                 block_id = randi([1, size(contexts, 2)], 1);
@@ -243,6 +245,8 @@ function update_parameters
                 identical_block_count = 1;
                 end
                 context_block = contexts(block_id);
+                outputSingleScan(Context_S,[0])
+                play_context_background(context_block, pink_noise_player, brown_noise_player, Context_S)
             end
             wh_rewarded_context = strcmp(context_block, mouse_rewarded_context);    
         end

--- a/utils_context/play_context_background.m
+++ b/utils_context/play_context_background.m
@@ -1,0 +1,24 @@
+function noise = play_context_background(block, pink_noise, brown_noise, session)
+%PLAY_CONTEXT_BACKGROUND Summary of this function goes here
+%   Detailed explanation goes here
+
+if strcmp(block, 'pink')
+    if ~ pink_noise.isplaying
+        pink_noise.play
+        if brown_noise.isplaying
+            brown_noise.pause
+        end
+    end
+    outputSingleScan(session,[1])
+elseif strcmp(block, 'brown')    
+    if ~ brown_noise.isplaying
+        brown_noise.play
+        if pink_noise.isplaying
+            pink_noise.pause
+        end
+    end
+    outputSingleScan(session,[1])
+end
+
+end
+

--- a/utils_savings/log_continuously.m
+++ b/utils_savings/log_continuously.m
@@ -1,7 +1,7 @@
 function log_continuously(~, event)
 
 global  Log_S_SR fid_continuous...
-        trial_start_ttl lick_threshold handles2give continuous_lick_data cam1_ttl cam2_ttl scan_pos
+        trial_start_ttl lick_threshold handles2give continuous_lick_data cam1_ttl cam2_ttl scan_pos context_flag context_ttl
 
 % Get and save data to binary file.
 % ---------------------------------
@@ -11,21 +11,29 @@ global  Log_S_SR fid_continuous...
 % ai2: trial start ttl
 % ai3: camera 1
 % ai4: camera 2
+% ai5: context transition
 
-data = [event.Data(:,1), event.Data(:,2), event.Data(:,3), event.Data(:,4), event.Data(:,5)]';
+data = [event.Data(:,1), event.Data(:,2), event.Data(:,3), event.Data(:,4), event.Data(:,5), event.Data(:,6)]';
 fwrite(fid_continuous, data, 'double');
 
 
 % Plot continuously.
 % ------------------
 
-% Plot trial start TTL.
+% Plot trial start TTL and context transition (if context task)
 
 trial_start_ttl = [trial_start_ttl, event.Data(:,3)'];
 trial_start_ttl = trial_start_ttl(end-10*Log_S_SR+1:end);
 time = [0:numel(trial_start_ttl)-1]/Log_S_SR;
-plot(handles2give.TrialStartTTL, time, trial_start_ttl, 'Color', 'k');
+if context_flag
+    context_ttl = [context_ttl, event.Data(:, 6)'];
+    context_ttl = context_ttl(end-10*Log_S_SR+1:end);
+    plot(handles2give.TrialStartTTL, time, trial_start_ttl, 'k', time, context_ttl, 'r');
+else
+    plot(handles2give.TrialStartTTL, time, trial_start_ttl, 'Color', 'k');
+end
 ylabel(handles2give.TrialStartTTL,'Trial TTL')
+
 % Set axes limits
 ylim(handles2give.TrialStartTTL, [-1 8]);
 xlim(handles2give.TrialStartTTL, [0 time(end)]);


### PR DESCRIPTION
Here I added a digital output to record the timing of the transition between contexts in the continuous logging (user defined channel to analog input ai5). Also needed to change the calibration coil file (uses ai6 instead of ai5). Context transition channel is plotted on the top of trial start signal if context experiment, otherwise not displayed.