### PR TITLE
updated is_reward trial by trial assignment for context task

### DIFF
--- a/update_parameters.m
+++ b/update_parameters.m
@@ -368,6 +368,14 @@ function update_parameters
     % CONSTANT reward delivery (also for association trials)
     elseif not(partial_reward_flag) || association_flag
         is_reward=1;
+
+        if context_flag
+            if is_whisker
+                is_reward=wh_reward;
+            elseif is_auditory
+                is_reward=aud_reward;
+            end
+        end
     end
 
     


### PR DESCRIPTION
I updated the is_reward assignment for each trial if is the context task, so that we can use is_reward more generally for NWB.
Let me know if you think it's good.